### PR TITLE
Headerナビゲーションの微調整

### DIFF
--- a/src/organisms/Header/Header.tsx
+++ b/src/organisms/Header/Header.tsx
@@ -44,7 +44,7 @@ export const Header: React.FC<Props> = ({ position = 'sticky', needGradation = f
       as="nav"
       background={backgroundColor}
       width="100vw"
-      px={theme.space[10]}
+      px={[theme.space[2], theme.space[2], theme.space[10], theme.space[10]]}
       py={[theme.space[2], theme.space[2], theme.space[5], theme.space[5]]}
       alignItems="center"
       justifyContent="center"


### PR DESCRIPTION
ナビゲーションがハンバーガーメニューで閉じられるときの左右のPaddingが広いのが気になったので微調整しますた

■ 修正前
![スクリーンショット 2020-05-02 21 04 34](https://user-images.githubusercontent.com/4346679/80863689-f9bcea00-8cb8-11ea-9207-3bd8cb736f86.png)

■ 修正後
![スクリーンショット 2020-05-02 21 06 17](https://user-images.githubusercontent.com/4346679/80863692-fe819e00-8cb8-11ea-92ae-f89ad13e35df.png)
